### PR TITLE
feat: add treesitter textobjects for structural navigation

### DIFF
--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -2,6 +2,9 @@ return {
   {
     "nvim-treesitter/nvim-treesitter",
     build = ":TSUpdate",
+    dependencies = {
+      { "nvim-treesitter/nvim-treesitter-textobjects" },
+    },
     config = function()
       require('nvim-treesitter.configs').setup({
         ensure_installed = "all",
@@ -10,6 +13,51 @@ return {
         highlight = {
           enable = true,
           additional_vim_regex_highlighting = false,
+        },
+        textobjects = {
+          select = {
+            enable = true,
+            lookahead = true,
+            keymaps = {
+              ["af"] = "@function.outer",
+              ["if"] = "@function.inner",
+              ["ac"] = "@class.outer",
+              ["ic"] = "@class.inner",
+              ["aa"] = "@parameter.outer",
+              ["ia"] = "@parameter.inner",
+              ["ab"] = "@block.outer",
+              ["ib"] = "@block.inner",
+            },
+          },
+          move = {
+            enable = true,
+            set_jumps = true,
+            goto_next_start = {
+              ["]m"] = "@function.outer",
+              ["]]"] = "@class.outer",
+            },
+            goto_next_end = {
+              ["]M"] = "@function.outer",
+              ["]["] = "@class.outer",
+            },
+            goto_previous_start = {
+              ["[m"] = "@function.outer",
+              ["[["] = "@class.outer",
+            },
+            goto_previous_end = {
+              ["[M"] = "@function.outer",
+              ["[]"] = "@class.outer",
+            },
+          },
+          swap = {
+            enable = true,
+            swap_next = {
+              ["<leader>s"] = "@parameter.inner",
+            },
+            swap_previous = {
+              ["<leader>S"] = "@parameter.inner",
+            },
+          },
         },
       })
     end,


### PR DESCRIPTION
## Summary
- Add nvim-treesitter-textobjects as a dependency of nvim-treesitter
- Select text objects: `af/if` (function), `ac/ic` (class), `aa/ia` (parameter), `ab/ib` (block)
- Move between structures: `]m/[m` (function), `]]/[[` (class)
- Swap parameters: `<leader>s` / `<leader>S`